### PR TITLE
Additional \n for icinga2 livestatus on query needed

### DIFF
--- a/netbox_nagios/livestatus.py
+++ b/netbox_nagios/livestatus.py
@@ -11,6 +11,7 @@ def hoststatus(hostname: str, livestatus_host: str, livestatus_port: int):
         "GET hosts\n"
         + "Filter: host_name = %s\n" % hostname  #
         + "OutputFormat: json\n"
+        + "\n"
     )
 
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)


### PR DESCRIPTION
I use icinga2 and the livestatus implementation there needs an additional \n to getting data from icinga2.

Not sure it this breaks MK Livestatus on Nagios, as i don't use it, can't test it, but maybe you had the chance to
retest if this fix for icinga2 needs some more "improvement", something like additional optional setting to 
add the final \n to the query?

Maybe this additional work is only needed if the change breaks Nagios/MK Livestatus!?